### PR TITLE
[math-mode] Added functionality for tokens2cmc and draw2cmc parameters.

### DIFF
--- a/src/math_mode/tests/test_mode.py
+++ b/src/math_mode/tests/test_mode.py
@@ -61,3 +61,6 @@ def test_tou2cmc():
 
 def test_draw2cmc():
     run_parameter_test("draw2cmc")
+
+def test_tokens2cmc():
+    run_parameter_test("tokens2cmc")


### PR DESCRIPTION
## Overview
This PR addresses Issue #8. As described, draw2cmc and tokens2cmc are now operational parameters a user can analyze cards with. This implementation is limited to math mode only.

### Changes
- Added a 'tokens2cmc' function to the MathReport class in **`src/math_mode/math_report.py`**
- Using Python's re library, I updated 'draw2cmc' and 'tokens2cmc' to use regular expression searching to locate utility values in a card's oracle text (i.e find the "draw a card" part of a card's textbox)
- Added a 'test_tokens2cmc' test to the **`src/math-mode/tests/test-mode.py`** file